### PR TITLE
Added in ignore rule for .DS_Store for Mac installations

### DIFF
--- a/lib/calipso.js
+++ b/lib/calipso.js
@@ -510,11 +510,11 @@ function loadModules(options) {
   // Read the modules in from the file system, sync is fine as we do it once on load.
   calipso.lib.fs.readdirSync(__dirname + '/../modules').forEach(function(type){
 
-    if(type != "README") {  // Ignore the readme file
+    if(type != "README" && type != '.DS_Store') {  // Ignore the readme file and .DS_Store file for Macs
 
       calipso.lib.fs.readdirSync(__dirname + '/../modules/' + type).forEach(function(name){
 
-        if(name != "README") { // Ignore the readme file
+        if(name != "README" && name != '.DS_Store') { // Ignore the readme file and .DS_Store file for Macs
 
               var enabled = configuredModules[name] && configuredModules[name].enabled;
 


### PR DESCRIPTION
Hi! I installed Calipso on my Mac system, it's awesome! :) 

The thing is when I start making any changes in the app, e.g. enable/disable a module the app crashes with the following error: 

Uncaught exception: Error: ENOTDIR, Not a directory '/Users/greyang/Sites/calipso/lib/../modules/.DS_Store'Error: ENOTDIR, Not a directory '/Users/greyang/Sites/calipso/lib/../modules/.DS_Store'
    at Object.readdirSync (fs.js:376:18)
    at /Users/greyang/Sites/calipso/lib/calipso.js:523:22
    at Array.forEach (native)
    at loadModules (/Users/greyang/Sites/calipso/lib/calipso.js:519:57)
    at /Users/greyang/Sites/calipso/lib/calipso.js:132:7
    at /Users/greyang/Sites/calipso/lib/calipso.js:848:5
    at /Users/greyang/Sites/calipso/lib/Theme.js:148:7
    at Function.done (/Users/greyang/Sites/calipso/lib/Theme.js:370:9)
    at next (/Users/greyang/Sites/calipso/support/step.js:58:23)
    at check (/Users/greyang/Sites/calipso/support/step.js:80:14)

So I figured adding the the .DS_Store into the ignore rules at Line 513 and Line 517 will fix the problem. And it did. 

I think we might want to add a generic ignore list file, or do an assert at the .forEach() to check if it's a directory or not before running the function. You'll never know what files people will want to put in there I guess. :/ 
