### PR TITLE
Added ignore rule for .DS_Store file

### DIFF
--- a/modules/core/admin/admin.module.js
+++ b/modules/core/admin/admin.module.js
@@ -89,9 +89,10 @@ function init(module, app, next) {
     calipso.lib.fs.readdir(app.path + '/themes', function(err, folders) {
 
       folders.forEach(function(name) {
-        calipso.data.themes.push(name);
+        if (name !='.DS_Store'){
+            calipso.data.themes.push(name);
+        }
       });
-
       calipso.data.loglevels = calipso.lib.winston.config.npm.levels;
       calipso.data.modules = calipso.modules;
 


### PR DESCRIPTION
Hi... did the same thing for the Themes, .DS_Store appeared again in the dropdown and if we choose that as a Theme in the Admin panel it crashes the app. :( 

So I added in the ignore .DS_Store statement in line 92 of admin.module.js. Hope it's okay. :) 
