### PR TITLE
Tables fix in admin interface

### DIFF
--- a/themes/cleanslate/public/css/admin.css
+++ b/themes/cleanslate/public/css/admin.css
@@ -40,3 +40,6 @@
   height: 15px;
 }
 
+#user-list, .tabular {
+	clear: both;
+}


### PR DESCRIPTION
Added clear:both. Without it tables were shifted to the right, outside the screen (in Firefox and Chrome, specifically)
