### PR TITLE
added class to indicate form field type

### DIFF
--- a/lib/Form.js
+++ b/lib/Form.js
@@ -302,7 +302,7 @@ CalipsoForm.prototype.render_field = function(field, value) {
   );
 
   return field.label || field.label.length > 0 ? (
-    '<div class="form-item" id="' + wrapperId + '-wrapper">' +
+    '<div class="form-item field-type-' + field.type + '" id="' + wrapperId + '-wrapper">' +
     '<div class="form-field">' +
       // put checkboxes and radios ("checkables") before their labels
       (isCheckable ? tagHTML : labelHTML) +


### PR DESCRIPTION
hey clifton,
As i was trying to style some form fields for my theme, I couldn't get as granular as i could with the current classes being implemented.  I added some helper/hook classes to help out.

right now, there is just `.form-item`.  With this addition, and say you're trying to style a select box area, you'll get something like `.form-item.field-type-select`.  or if you're trying to target a datetime, it's `.form-item.field-type-datetime`.

what do you think of this change?

thanks
dale
