### PR TITLE
broke scripts and styles into different routes, added to existing themes 

### DIFF
--- a/modules/community/richforms/richforms.js
+++ b/modules/community/richforms/richforms.js
@@ -42,10 +42,19 @@ function init(module, app, next) {
     }, this.parallel());
     module.router.addRoute(/.*/, allPages, {
       end: false,
+      template: 'datepicker.style',
+      block: 'styles.richforms.datepicker'
+    }, this.parallel());
+    module.router.addRoute(/.*/, allPages, {
+      end: false,
       template: 'markitup.script',
       block: 'scripts.richforms.markitup'
     }, this.parallel());
-
+    module.router.addRoute(/.*/, allPages, {
+      end: false,
+      template: 'markitup.style',
+      block: 'styles.richforms.markitup'
+    }, this.parallel());
     app.use(calipso.lib.express.static(__dirname + '/static'));
 
     module.router.addRoute('GET /richforms/preview', showPreview, {}, this.parallel());

--- a/modules/community/richforms/templates/datepicker.script.html
+++ b/modules/community/richforms/templates/datepicker.script.html
@@ -1,4 +1,3 @@
-<link href="/css/Aristo/jquery-ui-1.8.7.custom.css" rel="stylesheet">
 <script src="/js/jquery-ui-1.8.10.custom.min.js"></script>
 <script>
 // Iterate through datepicker elements and set values

--- a/modules/community/richforms/templates/datepicker.style.html
+++ b/modules/community/richforms/templates/datepicker.style.html
@@ -1,0 +1,1 @@
+<link href="/css/Aristo/jquery-ui-1.8.7.custom.css" rel="stylesheet">

--- a/modules/community/richforms/templates/markitup.script.html
+++ b/modules/community/richforms/templates/markitup.script.html
@@ -2,9 +2,6 @@
 <!-- markItUp! toolbar settings -->
 <script type="text/javascript" src="/js/markitup/sets/default/set.js"></script>
 <!-- markItUp! skin -->
-<link rel="stylesheet" type="text/css" href="/js/markitup/skins/markitup/style.css" />
-<!--  markItUp! toolbar skin -->
-<link rel="stylesheet" type="text/css" href="/js/markitup/sets/default/style.css" />
 <script type="text/javascript">
 $(document).ready(function()  {
 

--- a/modules/community/richforms/templates/markitup.style.html
+++ b/modules/community/richforms/templates/markitup.style.html
@@ -1,0 +1,3 @@
+<link rel="stylesheet" type="text/css" href="/js/markitup/skins/markitup/style.css" />
+<!--  markItUp! toolbar skin -->
+<link rel="stylesheet" type="text/css" href="/js/markitup/sets/default/style.css" />

--- a/themes/calipso/templates/default/styles.html
+++ b/themes/calipso/templates/default/styles.html
@@ -18,3 +18,4 @@
 <!--  Prettify -->
 <link href="/js/prettify/dessert.css" rel="stylesheet">
 
+<%- styles %>

--- a/themes/calipso/templates/default/styles.js
+++ b/themes/calipso/templates/default/styles.js
@@ -1,0 +1,22 @@
+/**
+ * Additional content section / block functions for scripts.
+ */
+
+var calipso = require("../../../../lib/calipso");
+
+exports = module.exports = function(req, options, callback) {
+
+  /**
+   *  Get additional content for blocks in the template
+   */
+  calipso.lib.step(
+    function getContent() {
+      options.getBlock(/styles.*/,this.parallel());
+    },
+    function done(err, styles) {
+      callback(err,{styles:styles});
+    }
+  );
+
+
+};

--- a/themes/cleanslate/templates/default/styles.html
+++ b/themes/cleanslate/templates/default/styles.html
@@ -6,3 +6,4 @@
 <link href="/css/admin-menu.css" rel="stylesheet">
 <% } %>
 <!-- put your stylesheet links here -->
+<%- styles %>

--- a/themes/cleanslate/templates/default/styles.js
+++ b/themes/cleanslate/templates/default/styles.js
@@ -1,0 +1,22 @@
+/**
+ * Additional content section / block functions for scripts.
+ */
+
+var calipso = require("../../../../lib/calipso");
+
+exports = module.exports = function(req, options, callback) {
+
+  /**
+   *  Get additional content for blocks in the template
+   */
+  calipso.lib.step(
+    function getContent() {
+      options.getBlock(/styles.*/,this.parallel());
+    },
+    function done(err, styles) {
+      callback(err,{styles:styles});
+    }
+  );
+
+
+};


### PR DESCRIPTION
i found that when including the dynamic scripts, styles were clumped with them.  if you moved the scripts to the bottom of the page, the styles followed.  i think it would be better to have this ability to separate styles from scripts, but still within the same module of course.  the changes follow the same constructs as the scripts includes.

dale
