### PR TITLE
adding helpers to get page id and page classes

### DIFF
--- a/lib/Helpers.js
+++ b/lib/Helpers.js
@@ -174,10 +174,6 @@ exports = module.exports = {
     };
   },
 
-  isAdminPage: function (req, res) {
-    return (/^\/admin/).test(req.url);
-  },
-
   /**
    * TODO Retrieve the concatenated / minified js scripts to add to template.
    */


### PR DESCRIPTION
what do you think of these additions?  this gives easy access to add in classes based on the url to a div and likewise for an id.  the only difference is that each "directory" after the domain will be a class but for an id, they will all be concatenated.

page: /admin/core/config 
classes => .admin.core.config
id => admin-core-config

the `isAdmin` method also allows for excluding anything easily by checking if the request url is coming from an admin page.  I didn't think about this until just now, but will that admin url be customizable?  Will someone be able to change the path to the admin?  if so, that change my not work out then.
