### PR TITLE
theme fallback, general utils file

### DIFF
--- a/app.js
+++ b/app.js
@@ -138,6 +138,7 @@ function bootApplication(app, next) {
   // Translation - after static, set to add mode if appropriate
   app.use(translate.translate(app.set('config').language, app.set('language-add')));
 
+  calipso.defaultTheme = require(path + '/conf/configuration.js').getDefaultTheme();
   // Core calipso router
   app.use(calipso.calipsoRouter(app, app.set('config'), function() {
     next();

--- a/conf/configuration.js
+++ b/conf/configuration.js
@@ -1,5 +1,7 @@
 var mongoose = require('mongoose'),
     Schema = mongoose.Schema;
+    
+var defaultTheme = 'cleanslate';
 
 /**
  * Default configuration manager This file controls the loading, and initial
@@ -18,7 +20,7 @@ module.exports = function(app, express, next) {
   var defaultConfig = {
     version:1,  // Used to warn - e.g. structural changes require a config reset
     cache: false,
-    theme: 'cleanslate',
+    theme: defaultTheme,
     language: 'en',
     install: true,
     cryptoKey: createRandomString(),
@@ -150,6 +152,11 @@ module.exports = function(app, express, next) {
     });
   });
 
+};
+
+// prefer a getter since a property can be overwritten
+module.exports.getDefaultTheme = function () {
+  return defaultTheme; 
 };
 
 /**

--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -1,0 +1,58 @@
+/**
+ * General utility methods
+ */
+ 
+exports = module.exports = {
+  /**
+   * Basically like getProperty, different return
+   * @method hasProperty
+   * @param ns {string} A period delimited string of the namespace to find, sans root object
+   * @param obj {object} The root object to search
+   * @return {boolean} true if property exists, false otherwise
+   */
+  hasProperty: function (ns, obj) {
+		if (!ns) {
+			return obj;
+		}
+		var nsArray = ns.split('.'),
+			nsLen	= nsArray.length,
+			newNs;
+
+		// if nsLen === 0, then obj is just returned
+		while (nsLen > 0) {
+			newNs = nsArray.shift();
+			if (obj[newNs]) {
+				obj = obj[newNs];
+			} else {
+			  return false;
+			}
+			nsLen = nsArray.length;
+		}
+		return true;
+  },
+  /**
+   * Find a namespaced property
+   * @method getProperty
+   * @param ns {string} A period delimited string of the namespace to find, sans root object
+   * @param obj {object} The root object to search
+   * @return {object} the object, either the namespaced obejct or the root object
+   */
+	getProperty: function (ns, obj) {
+		if (!ns) {
+			return obj;
+		}
+		var nsArray = ns.split('.'),
+			nsLen	= nsArray.length,
+			newNs;
+
+		// if nsLen === 0, then obj is just returned
+		while (nsLen > 0) {
+			newNs = nsArray.shift();
+			if (obj[newNs]) {
+				obj = obj[newNs];
+			}
+			nsLen = nsArray.length;
+		}
+		return obj;
+	}
+}

--- a/lib/calipso.js
+++ b/lib/calipso.js
@@ -72,7 +72,8 @@ calipso = exports = module.exports = {
   table: require('./Table').CalipsoTable,
   link: require('./Link').CalipsoLink,
   menu: require('./Menu'),
-  event: require('./Event'),        
+  event: require('./Event'),
+  utils: require('./Utils'),
   notifyDependenciesOfInit: notifyDependenciesOfInit,
   notifyDependenciesOfRoute: notifyDependenciesOfRoute,
   e: {},
@@ -839,7 +840,9 @@ function loadModuleTemplates(module, moduleTemplatePath) {
     var templateName = name.replace(/\.([^\.]+)$/,'');
 
     // Load the template - only if not already loaded by theme (e.g. overriden)
-    if(calipso.theme.cache.modules && calipso.theme.cache.modules[module.name] && calipso.theme.cache.modules[module.name].templates[templateName]) {
+    var hasTemplate = calipso.utils.hasProperty('theme.cache.modules.' + module.name + '.templates.' + templateName, calipso);
+    
+    if (hasTemplate) {
 
        // Use the theme version
        templates[templateName] = calipso.theme.cache.modules[module.name].templates[templateName];
@@ -876,26 +879,33 @@ function loadModuleTemplates(module, moduleTemplatePath) {
 /**
  * Configure a theme using the theme library.
  */
-function configureTheme(next) {
+function configureTheme(next, overrideTheme) {
 
-  var themeName = calipso.app.set('config').theme;
+  var themeName = overrideTheme ? overrideTheme : calipso.app.set('config').theme;
 
   require('./Theme').Theme(themeName,function(theme) {
 
     calipso.theme = theme;
+    if (!calipso.theme) {
+      var dt = calipso.defaultTheme;
+      calipso.error('THE `' + themeName + '` THEME IS MISSING, USING DEFAULT THEME `' + dt + '`')
+      configureTheme(next, dt);
 
-    // Search for middleware that already has themeStatic tag
-    calipso.app.stack.forEach(function(middleware,key) {
-     if(middleware.handle.tag === 'themeStatic') {
-        // Replace it
-        var oneDay = 86400000;
-        var themeStatic = calipso.lib.express.static(calipso.app.path + '/themes/' + themeName + '/public',{maxAge:oneDay});        
-        themeStatic.tag = 'themeStatic';
-        calipso.app.stack[key].handle = themeStatic;
-     }
-    });
+    } else {
 
-    next();
+      // Search for middleware that already has themeStatic tag
+      calipso.app.stack.forEach(function(middleware,key) {
+       if(middleware.handle.tag === 'themeStatic') {
+          // Replace it
+          var oneDay = 86400000;
+          var themeStatic = calipso.lib.express.static(calipso.app.path + '/themes/' + themeName + '/public',{maxAge:oneDay});        
+          themeStatic.tag = 'themeStatic';
+          calipso.app.stack[key].handle = themeStatic;
+       }
+      });
+
+      next();
+    }
 
   });
 


### PR DESCRIPTION
I ran into this problem today when i updated my dev branch and forgot that I had renamed my current working theme.  the site borked on reload so i figured out a way to get it back to a working order so at least you can change your theme back.

I also added a general utils file (lib/Utils.js).  right now it has to methods: hasProperty and getProperty (not DRY atm).  This helps eliminate a statement like this:

```
if(calipso.theme.cache.modules && calipso.theme.cache.modules[module.name] && calipso.theme.cache.modules[module.name].templates[templateName]) { ... }
```

instead, it can now be written like this:

```
var hasTemplate = calipso.utils.hasProperty('theme.cache.modules.' + module.name + '.templates.' + templateName, calipso);

if (hasTemplate) { ... } 
```
