### PR TITLE
fix inquiry of npm's root and global root

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -28,8 +28,8 @@ else
 fi
 
 # Quick check of key modules
-npm_local=$(npm root)
-npm_global=$(npm root -g)
+npm_local=$(npm config get root)
+npm_global=$(npm config get root -g)
 echo 'Checking that key modules are installed...'
 for module in "${KEY_MODULES[@]}"; do
     echo -n "  $module module ... "


### PR DESCRIPTION
What a I stumbled uppon installing calipso:

I belive the correct syntax for the inquiry of npm's root is >npm config get root< instead of >npm root<. 
The current version 0.3.18 will fail with >npm root<. and this fix worked for me.
