### PR TITLE
dynamically return error code files if found in themes folder

### DIFF
--- a/lib/Theme.js
+++ b/lib/Theme.js
@@ -399,7 +399,7 @@ function cacheTheme(theme, themePath, next) {
       // Select files that start with 3 digits, indicating an error code
       return filename.match(/^\d{3}./);
     });
-  
+
     calipso.lib._.each(errorCodeTemplates, function(filename){
       templates.push({name: filename.match(/^\d{3}/), templatePath: "templates/" + filename});
     });


### PR DESCRIPTION
Hi there! I was converting the templates of Cleanslate from EJS to Jade, and when I changed the 404.html/500.html to 404.jade/500.jade Calipso throws an error, saying that the file not found. Then I later found out that it's due to the two files are being hard-coded at themes.js.

I'm proposing that the error templates are to be dynamically returned from the theme folder using regular expression, matching 3 digits indicating it's a template for any error code. This way it will automatically detect the file extension as well, which in turn compiles the template correctly (whether with EJS or Jade). 

I hope this is okay :) 
