### PR TITLE
The month field of the published/schedule date is always Jan. This patch is to fix that

### DIFF
--- a/lib/Form.js
+++ b/lib/Form.js
@@ -507,7 +507,7 @@ CalipsoForm.prototype.render_tag_date = function(field, value) {
   + ' name="' + field.name + '[month]">';
   for(var monthNameCounter=0; monthNameCounter<12; monthNameCounter++) {
     tagOutput += (
-      '<option value="0"' + (value.getMonth() === monthNameCounter ? ' selected' : '') + '>'
+      '<option value="' + monthNameCounter + '"' + (value.getMonth() === monthNameCounter ? ' selected' : '') + '>'
       + monthNames[monthNameCounter]
       + '</option>'
     );


### PR DESCRIPTION
... the monthNameCounter instead of zero. This is to ensure the published/schedule date of the content status is not always Jan
