### PR TITLE
Add support for spaces in Path

### DIFF
--- a/bin/calipso
+++ b/bin/calipso
@@ -30,7 +30,7 @@ var argv = require('optimist')
  * path = directory script being run from
  * calipsoPath = calipso library installation path
  **/
-var path = fs.realpathSync('.');
+var path = fs.realpathSync('.').replace(/\s/g,'\\ ');
 var calipsoPath = __dirname + "/../";
 var step = require('step');
 
@@ -251,7 +251,7 @@ function createApplicationAt(path) {
  * Run the install shell script
  */
 function runInstall(path) {
-
+  path = path.replace(/\\\s/g, ' ');
   exec('./bin/siteInstall.sh', { timeout: 60000, cwd:path }, function (error, stdout, stderr) {
       console.log(stdout);
       console.log(stderr);


### PR DESCRIPTION
the command line tool was failing on my system since I had directories
with spaces in them. mkdir was interpreting the path as multiple paths.

I had to undo the escape character because node didn't work well with it. 

Eventually, it would make sense to move to using the node library to perform the path operations so you don't have to deal with escape characters. Eg. https://gist.github.com/864454
