### PR TITLE
-- Update bcrypt to > 0.6.x as version 0.5 will fail with node 0...

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "step": "0.0.x",
     "optimist":"0.3.x",
     "colors":"0.6.x",
-    "bcrypt": "0.5.x",
+    "bcrypt": "0.7.x",
     "semver":"1.0.x",
     "zipfile":"0.3.x",
     "rimraf":"2.0.x",


### PR DESCRIPTION
....8. Latest bcrypt version are built upon node-gyp, which makes it easier to setup on every machine without mach-o issues. I'm not sure whether I'm the only one that had the issue. But that might fix it for further users.
