### PR TITLE
Added uri policy to string properties of contentType

### DIFF
--- a/modules/core/content/content.js
+++ b/modules/core/content/content.js
@@ -196,7 +196,7 @@ function getContent(req, options, next) {
 				var prop;
 				for (var prop in c) {
 					if (typeof c[prop] === 'string') {
-						c[prop] = sanitizer.sanitize(c[prop]);
+						c[prop] = sanitizer.sanitize(c[prop], function uri_policy(uri) { return uri; });
 					}
 				}
 


### PR DESCRIPTION
I noticed links were still being filtered out, because the contentType object's string properties didn't have a uriPolicy applied.  I've made this update.  See if it resolves things.

Related to issue #102
