### PR TITLE
Fix table sort for mongoose

### DIFF
--- a/lib/core/Table.js
+++ b/lib/core/Table.js
@@ -153,22 +153,8 @@ function getHeaderClass(table, column) {
  */
 CalipsoTable.prototype.sortQuery = function (qry, sortBy) {
 
-  if (typeof sortBy === 'string') {
-    sortBy = [sortBy];
-  }
-  if (!sortBy || sortBy.length === 0) {
-    return qry;
-  }
+  return qry.sort(this.parseSort(sortBy));
 
-  sortBy.forEach(function (sort) {
-    var sortArr = sort.split(",");
-    if (sortArr.length === 2) {
-      var dir = sortArr[1] === 'asc' ? 1 : (sortArr[1] === 'desc' ? -1 : 0);
-      qry = qry.sort(sortArr[0], dir);
-    }
-  });
-
-  return qry;
 };
 
 


### PR DESCRIPTION
Mongoose sort syntax change.  parseSort function was already in place -- call it from sortQuery.
