### PR TITLE
feat(lib/core/Logging.js): log to console during bootstrap

### DIFF
--- a/lib/core/Logging.js
+++ b/lib/core/Logging.js
@@ -28,7 +28,10 @@ exports = module.exports.configureLogging = configureLogging;
  */
 
 function configureLogging(options) {
-  options = options || calipso.config.get('logging');
+  // if logging is not yet configured, log to console
+  options = options ||
+      (calipso.config && calipso.config.get('logging')) ||
+      { console: { enabled: true } };
 
   //Configure logging
   var logMsg = "\x1b[36mLogging enabled: \x1b[0m",
@@ -81,3 +84,10 @@ function configureLogging(options) {
   calipso.error = winston.error;
 
 }
+
+// go ahead and configure logging without options now --
+// it can and will be reconfigured later, but other modules
+// may try to log as they load (e.g. storage).  prior to
+// reading options logging to console is enabled to allow
+// bootrapping processes to emit information.
+configureLogging();


### PR DESCRIPTION
When the logging library is loaded, initially configure loggging
to the console so that the boostrap process can provide information.
