### PR TITLE
fix(app.js): parse node.env.PORT

### DIFF
--- a/app.js
+++ b/app.js
@@ -169,7 +169,7 @@ function calipsoFindOrCreateUser(user, sess, promise) {
 // Local App Variables
 var path = rootpath,
   theme = 'default',
-  port = process.env.PORT || 3000;
+  port = (process.env.PORT && parseInt(process.env.PORT)) || 3000;
 
 /**
  * Catch All exception handler


### PR DESCRIPTION
Parse node.env.PORT as an integer so that it succeeds comparison with
port in use and is not logged as an error.
