### PR TITLE
test(core/lib/Theme.js): test for schema-valid theme.json

### DIFF
--- a/lib/calipso.js
+++ b/lib/calipso.js
@@ -327,7 +327,7 @@ function configureTheme(next, overrideTheme) {
       console.error("Unable to locate the theme: " + themeName + ", terminating.");
       process.exit();
     } else {
-      calipso.error('The `' + themeName + '` theme is missing, trying the defaul theme: `' + defaultTheme + '`');
+      calipso.error('The `' + themeName + '` theme is missing, trying the default theme: `' + defaultTheme + '`');
       configureTheme(next, defaultTheme);
     }
 

--- a/lib/core/Themes.js
+++ b/lib/core/Themes.js
@@ -457,6 +457,112 @@ function sectionCache(req, res, cacheKey, section, templateName, layoutConfig, t
 
 
 /**
+ * schema to validate a theme.json file.
+ * We cannot use schema to validate the level below
+ * layouts because it is not an array -- must manually loop
+ * them seperately.
+ * @type {Object}
+ */
+var themeJsonSchema = {
+  id: "/theme",
+  type: "object",
+  properties: {
+    name: { type: "string", required: true },
+    type: { type: "string", required: true },
+    description: { type: "string", required: true },
+    version:  { type: "string", required: true },
+    author: { type: "string", required: true },
+    layouts: {
+      type: "object",
+      required: true
+      //TODO: are certain layouts (e.g. default) required?
+    }
+  }
+};
+
+/**
+ * schema to validate a layout property in a theme.json file.
+ * This schema is used in a loop because the layouts are not defined
+ * in an array as the schema validator would require.
+ *
+ * This schema is NOT comprehensive (yet).
+ * @type {Object}
+ */
+var layoutSchema = {
+  id: "/layout",
+  type: "object",
+  properties: {
+    layout: {
+      type: "object",
+      required: true,
+      properties: {
+        template: { type: "string", required: true }
+      }
+    }
+
+  }
+
+}
+
+/**
+ * Test the schema-validity of a theme's json object.
+ * @param  {Object}   themeJson object that is the theme.json
+ * @param  {Function} next      aynsc func to call
+ * @return {undefined}
+ */
+function validateThemeJsonSchema(themePath, themeJson, next) {
+  var validator = new (require("jsonschema").Validator)();
+  var _ = require("underscore");
+
+  var errors = [];
+
+  var themeName = themeJson.name;
+  if (!themeName) {
+    next(
+      new Error("theme.json at \"" + themePath + "\"" +
+        " has no name property!")
+    );
+  }
+  else {
+    var validation = validator.validate(
+      themeJson,
+      themeJsonSchema,
+      { propertyName: "[theme]" }
+    );
+    if (validation.errors.length) {
+      errors.push(validation.errors);
+    }
+
+    _.each(themeJson.layouts, function(layout, layoutName) {
+      layoutName = "[theme].layouts." + layoutName;
+      validation = validator.validate(
+        layout,
+        layoutSchema,
+        { propertyName: layoutName }
+      );
+      if (validation.errors.length) {
+        errors.push(validation.errors);
+      }
+    });
+
+    if (errors.length) {
+      next(
+        new Error("in theme: \"" + themeName + "\": schema error(s): " +
+            errors.join("; "))
+      );
+    }
+    else {
+      next(null);
+    }
+  }
+}
+
+function validateThemeFiles() {
+
+}
+
+
+/**
  * Load a theme
  */
 
@@ -471,10 +577,23 @@ function loadTheme(theme, themePath, next) {
           var jsonData;
           try {
             jsonData = JSON.parse(data);
-            next(null, jsonData);
+
           } catch (ex) {
             next(new Error("Error parsing theme configuration: " + ex.message + " stack, " + ex.stack));
           }
+
+          validateThemeJsonSchema(themePath, jsonData, function(err) {
+            if (err) {
+              next(err);
+            }
+            else {
+              // validateThemeFiles!!!
+
+              next(err, jsonData);
+
+            }
+          });
+
         } else {
           next(err);
         }
@@ -534,7 +653,14 @@ function cacheTheme(themeConfig, themePath, next) {
     }
 
     // Push error message templates
-    templateFiles = calipso.lib.fs.readdirSync(calipso.lib.path.join(themePath, 'templates', 'error'));
+    var errTemplatesPath = calipso.lib.path.join(themePath, 'templates', 'error');
+
+    if (!calipso.lib.fs.existsSync(errTemplatesPath)) {
+      calipso.warn("in theme \"" + themeConfig.name + "\": templates directory \"error\" not found.");
+    }
+    else {
+      templateFiles = calipso.lib.fs.readdirSync(calipso.lib.path.join(themePath, 'templates', 'error'));
+    }
     errorCodeTemplates = calipso.lib._.select(templateFiles, function (filename) {
       // Select files that start with 3 digits, indicating an error code
       return filename.match(/^\d{3}./);

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
         "adm-zip": "0.1.x",
         "node-xml": "1.0.x",
         "knox": "0.0.x",
-        "sanitizer": "0.0.15"
+        "sanitizer": "0.0.15",
+        "jsonschema": "~0.4.0"
     },
     "optionalDependencies": {
         "bcrypt": "0.7.x",

--- a/test/fixtures/themes/custom/invalid-schema/theme.json
+++ b/test/fixtures/themes/custom/invalid-schema/theme.json
@@ -1,0 +1,73 @@
+{
+  "name": "cleanslate-jade",
+  "description": "Jade version of Calipso's cleanslate theme",
+  "version": "0.1.0",
+  "author": "Grey Ang <conancat@gmail.com>",
+  "layouts": {
+    "default": {
+      "layout": {
+        "template": "default.jade",
+        "sections": {
+          "scripts": {"template": "scripts.jade"},
+          "styles": {"template": "styles.jade"},
+          "admin": {"menu": "admin", "template": "adminMenu.jade"},
+          "primary": {"menu": "primary", "template": "primaryMenu.jade"},
+          "secondary": {"template": "secondaryMenu.jade"},
+          "messages": {"template": "messages.jade"},
+          "body": {"template": "body.jade"},
+          "sidePanel": {"template": "sidePanel.jade"},
+          "footer": {"template": "footer.jade"}
+        }
+      }
+    },
+    "home": {
+      "layout": {
+        "copyFrom": "default",
+        "sections": {
+          "body": {"template": "body.jade"}
+        }
+      }
+    },
+    "blogLanding": {
+      "layout": {
+        "copyFrom": "default",
+        "sections": {
+          "body": {"template": "body.jade"}
+        }
+      }
+    },
+    "admin": {
+      "layout": {
+        "template": "admin.jade",
+        "sections": {
+          "scripts": {"template": "scripts.jade"},
+          "styles": {"template": "styles.jade"},
+          "admin": {"menu": "admin", "template": "adminMenu.jade"},
+          "primary": {"menu": "primary", "template": "primaryMenu.jade"},
+          "secondary": {"template": "secondaryMenu.jade"},
+          "messages": {"template": "messages.jade"},
+          "body": {"template": "body.jade"},
+          "footer": {"template": "footer.jade"}
+        }
+      }
+    },
+    "preview": {
+      "layout": {
+        "template": "preview.jade",
+        "sections": {
+          "scripts": {"template": "scripts.jade"},
+          "styles": {"template": "styles.jade"},
+          "body": {"template": "body.jade"}
+        }
+      }
+    },
+    "rss": {
+      "layout": {
+        "template": "rss.jade",
+        "sections": {
+          "body": {"template": "body.html"}
+        }
+      }
+    }
+  }
+}

--- a/test/lib.core.themes.js
+++ b/test/lib.core.themes.js
@@ -8,17 +8,54 @@ var should = require('should'),
   exec = require('child_process').exec,
   Themes = require('./helpers/require')('core/Themes');
 
+
+/**
+ * Create a theme config from a path to the json file
+ * @param  {string} path Path to json file, relative to the fixtures/themes
+ *                       directory (e.g. core/mocha/theme.json)
+ * @return {Object}      object with name and path properties
+ */
+getThemeConfig = function(path) {
+  var themeConfig = {
+    name: path.match(/\/([^\/\.]+)\.json$/)[1],
+    path : __dirname + '/' + path.match(/(.+)\/[^\/]+\.json/)[1] + '/'
+  };
+  return themeConfig;
+};
+
 describe('Themes', function () {
 
   before(function () {
-    // 
+    //
   });
 
   describe('Core', function () {
 
+    var returned = false;
 
-    it('I am a placeholder', function () {
-      true.should.equal(true);
+    it('I can instantiate a valid theme.json', function (done) {
+      Themes.Theme(
+        getThemeConfig('fixtures/themes/core/mocha/theme.json'),
+        function(err, theme) {
+          should.not.exist(err);
+          theme.should.be.ok;
+          done();
+        }
+      );
+    });
+
+    it('I can find errors in an invalid theme.json', function (done) {
+      // NOTE: we're looking for specific errors that are in the invalid-schema
+      // fixture -- not a comprehensive, and only ever as comprehensive
+      // as the schema validator, anyway
+      Themes.Theme(
+        getThemeConfig('fixtures/themes/custom/invalid-schema/theme.json'),
+        function(err, theme) {
+          err.should.match(/\[theme\]\.type is required/);
+          err.should.match(/\[theme\]\.layouts\.home\.layout\.template is required/);
+          done();
+        }
+      );
     });
 
   });


### PR DESCRIPTION
Initial support for validating a theme.json file.  Uses node package "jsonschema" to define a schema for theme.json and test validity of instances.  Report failures as hard errors.
