### PR TITLE
#246 fix TypeError: Cannot read property 'length' of undefined

### DIFF
--- a/modules/core/field/field.js
+++ b/modules/core/field/field.js
@@ -277,7 +277,7 @@ function processFieldConfiguration(event, formData, next) {
     }
   }
 
-  if (form.addSection.length) {
+  if (typeof form.addSection !== 'undefined' && form.addSection.length) {
     if (typeof jsonObject.sections === 'undefined') {
       jsonObject.sections = [];
     }


### PR DESCRIPTION
#246 fix TypeError: Cannot read property 'length' of undefined when trying to save custom fields

https://github.com/cliftonc/calipso/issues/246
