### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ npm), and should be run on site install.
   [Nate Hunzaker]: https://github.com/nhunzaker
   [Andreas Richter]: https://github.com/richtera
 
-#MIT License
+# MIT License
 
 Copyright (c) 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
